### PR TITLE
feat: initial ERCOT RTM sentiment project

### DIFF
--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -1,0 +1,41 @@
+name: Hourly ERCOT Collector
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run collector
+        run: python collector.py --lookback 6
+
+      - name: Commit updated data
+        run: |
+          if [[ -n "$(git status --porcelain data/ercot.parquet)" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add data/ercot.parquet
+            git commit -m "chore: update ERCOT data"
+            git push
+          else
+            echo "No data changes detected"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+.env
+.venv/
+venv/
+.data/
+*.log
+data/*.parquet
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8501
+
+CMD ["streamlit", "run", "streamlit_app.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,108 @@
+# ERCOT RTM Sentiment Project
+
+This project collects ERCOT real-time market (RTM) data, computes a consumer sentiment index, and exposes the results through a Streamlit dashboard and optional FastAPI service. Data is stored in an append-only Parquet file (`data/ercot.parquet`) with hourly updates and automatic deduplication.
+
+## Features
+
+- **Automated collector** using the [`gridstatus`](https://github.com/kmax12/gridstatus) library to pull RTM price and system load data from ERCOT each hour.
+- **Sentiment engine** that compares price and load to a 7-day rolling baseline using robust statistics and weighted scoring.
+- **Streamlit + Plotly dashboard** for interactive exploration with zone selection, timezone toggle, KPI cards, and charts for price, load, and sentiment.
+- **FastAPI microservice** providing `/latest` and `/history` endpoints for programmatic access.
+- **Parquet storage** with append + deduplicate logic to keep the dataset tidy.
+- **Automation-ready** GitHub Actions workflow that can run hourly and commit refreshed data.
+- **Dockerized deployment** targeting the Streamlit app by default.
+
+## Project Structure
+
+```
+app/
+  api.py            # FastAPI service
+  fetch.py          # gridstatus integrations
+  locations.py      # zone/hub normalization utilities
+  sentiment.py      # sentiment scoring logic
+  storage.py        # parquet helpers
+collector.py        # CLI collector entrypoint
+streamlit_app.py    # Streamlit dashboard
+requirements.txt    # Python dependencies
+Dockerfile          # Container definition for the dashboard
+.github/workflows/hourly.yml  # GitHub Actions workflow
+```
+
+## Getting Started Locally
+
+1. **Create a virtual environment** (recommended):
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. **Install dependencies**:
+   ```bash
+   pip install --upgrade pip
+   pip install -r requirements.txt
+   ```
+
+3. **Run the collector** to populate `data/ercot.parquet`:
+   ```bash
+   python collector.py --lookback 168  # fetch last 7 days on first run
+   ```
+
+   Subsequent runs can use the default 48-hour lookback to refresh recent history.
+
+4. **Launch the Streamlit dashboard**:
+   ```bash
+   streamlit run streamlit_app.py
+   ```
+
+   The app listens on <http://localhost:8501> by default. Select a zone or hub, adjust the timezone, and explore the charts.
+
+5. **Start the FastAPI service (optional)**:
+   ```bash
+   uvicorn app.api:app --reload --port 8000
+   ```
+
+   - `GET /latest?zone=NORTH` returns the latest row for the specified zone/hub.
+   - `GET /history?zone=HB_HOUSTON&hours=72` returns the last 72 hours for that location (capped at 14 days).
+
+## Scheduling & Automation
+
+- **Local cron** example (run every hour):
+  ```cron
+  0 * * * * /usr/bin/env bash -c 'cd /path/to/project && source .venv/bin/activate && python collector.py --lookback 6 >> collector.log 2>&1'
+  ```
+
+- **GitHub Actions**: The workflow at `.github/workflows/hourly.yml` runs hourly, executes the collector, commits the updated Parquet file, and pushes the change back to the repository when data changes are detected.
+
+## Deployment Options
+
+### Docker
+
+Build and run the containerized Streamlit app:
+
+```bash
+docker build -t ercot-rtm .
+docker run -p 8501:8501 -v $(pwd)/data:/app/data ercot-rtm
+```
+
+Mounting the `data/` directory preserves the Parquet history across restarts.
+
+### Streamlit Community Cloud
+
+1. Push this repository to GitHub.
+2. In Streamlit Cloud, create a new app pointing to `streamlit_app.py`.
+3. Configure secrets/environment variables if needed (e.g., GitHub token for the workflow).
+4. Ensure the `data/` directory is persisted via an external storage solution if long-term history is required.
+
+### FastAPI Hosting
+
+Deploy the FastAPI service (e.g., on Railway, Fly.io, or Azure App Service) by running `uvicorn app.api:app --host 0.0.0.0 --port 8000`. Mount or synchronize the `data/ercot.parquet` file to keep the API in sync with the collector.
+
+## Development Tips
+
+- The collector logs to stdout. Use the `--verbose` flag for detailed logging when troubleshooting.
+- Sentiment thresholds: green ≥ 70, yellow 40–69, red < 40.
+- Rolling baselines use 7 days (168 hours) of history with at least 24 observations before scoring.
+
+## License
+
+This project is released under the [MIT License](LICENSE).

--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,79 @@
+"""FastAPI application exposing ERCOT RTM data."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+import pandas as pd
+from fastapi import FastAPI, HTTPException, Query
+from pydantic import BaseModel
+
+from app.locations import CANONICAL_LOCATIONS, normalize_location
+from app.storage import load_dataset
+
+app = FastAPI(title="ERCOT RTM API", version="0.1.0")
+
+
+class MarketRow(BaseModel):
+    timestamp: datetime
+    zone: str
+    price: float
+    system_load: float
+    sentiment: float
+    sentiment_bucket: str
+
+    @classmethod
+    def from_series(cls, row: pd.Series) -> "MarketRow":
+        timestamp = row["timestamp"]
+        if isinstance(timestamp, pd.Timestamp):
+            timestamp = timestamp.to_pydatetime()
+        return cls(
+            timestamp=timestamp,
+            zone=str(row["zone"]),
+            price=float(row["price"]),
+            system_load=float(row["system_load"]),
+            sentiment=float(row["sentiment"]),
+            sentiment_bucket=str(row["sentiment_bucket"]),
+        )
+
+
+@app.get("/")
+def root() -> dict[str, str]:
+    return {"message": "ERCOT RTM API. Use /latest or /history endpoints."}
+
+
+def _filter_zone(df: pd.DataFrame, zone: str) -> pd.DataFrame:
+    canonical = normalize_location(zone)
+    if canonical is None or canonical not in CANONICAL_LOCATIONS:
+        raise HTTPException(status_code=404, detail=f"Unknown zone '{zone}'")
+
+    zone_df = df[df["zone"] == canonical]
+    if zone_df.empty:
+        raise HTTPException(status_code=404, detail=f"No data for zone '{canonical}'")
+    return zone_df.sort_values("timestamp")
+
+
+@app.get("/latest", response_model=MarketRow)
+def latest(zone: str = Query(..., description="Zone or hub name")) -> MarketRow:
+    df = load_dataset()
+    if df.empty:
+        raise HTTPException(status_code=404, detail="Dataset is empty")
+    zone_df = _filter_zone(df, zone)
+    row = zone_df.iloc[-1]
+    return MarketRow.from_series(row)
+
+
+@app.get("/history", response_model=List[MarketRow])
+def history(
+    zone: str = Query(..., description="Zone or hub name"),
+    hours: int = Query(24, gt=0, le=24 * 14, description="Number of hours of history to return"),
+) -> List[MarketRow]:
+    df = load_dataset()
+    if df.empty:
+        raise HTTPException(status_code=404, detail="Dataset is empty")
+
+    zone_df = _filter_zone(df, zone)
+    latest_timestamp = zone_df["timestamp"].max()
+    cutoff = latest_timestamp - pd.Timedelta(hours=hours - 1)
+    recent = zone_df[zone_df["timestamp"] >= cutoff]
+    return [MarketRow.from_series(row) for _, row in recent.iterrows()]

--- a/app/fetch.py
+++ b/app/fetch.py
@@ -1,0 +1,253 @@
+"""Utilities for fetching ERCOT real-time market data."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Iterable, List, Optional
+
+import pandas as pd
+
+try:
+    from gridstatus import Ercot  # type: ignore
+except ImportError as exc:  # pragma: no cover - handled at runtime
+    raise ImportError(
+        "The gridstatus package is required to fetch ERCOT data."
+    ) from exc
+
+from app.locations import CANONICAL_LOCATIONS, normalize_location
+
+logger = logging.getLogger(__name__)
+
+# Columns that may represent timestamps in gridstatus DataFrames
+_TIME_COLUMN_CANDIDATES = [
+    "timestamp",
+    "time",
+    "datetime",
+    "Delivery Interval",
+    "Delivery Interval Ending",
+    "Interval Ending",
+    "Oper Interval",
+    "Settlement Point Price Date",
+    "Settlement Point Price Timestamp",
+]
+
+# Columns that may contain location/settlement point names
+_LOCATION_COLUMN_CANDIDATES = [
+    "location",
+    "Location",
+    "Settlement Point",
+    "settlement_point",
+    "Load Zone",
+    "SettlementPoint",
+]
+
+# Columns that may contain RTM price values
+_PRICE_COLUMN_CANDIDATES = [
+    "lmp",
+    "price",
+    "Price",
+    "Settlement Point Price",
+    "Settlement Point Price ($/MWH)",
+    "SettlementPointPrice",
+]
+
+# Columns that may contain system load values
+_LOAD_COLUMN_CANDIDATES = [
+    "System Load",
+    "Actual System Load",
+    "Actual Load",
+    "Load",
+    "Actual Load (MW)",
+    "actual_load",
+]
+
+
+@dataclass
+class FetchConfig:
+    """Configuration for data collection."""
+
+    lookback_hours: int = 48
+
+    @property
+    def start_time(self) -> datetime:
+        """Start timestamp for data collection in UTC."""
+        end = datetime.now(tz=timezone.utc)
+        return end - timedelta(hours=self.lookback_hours)
+
+    @property
+    def end_time(self) -> datetime:
+        """End timestamp for data collection in UTC."""
+        return datetime.now(tz=timezone.utc)
+
+
+def _detect_column(frame: pd.DataFrame, candidates: Iterable[str]) -> Optional[str]:
+    for col in candidates:
+        if col in frame.columns:
+            return col
+    return None
+
+
+def _prepare_price_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    """Normalize various gridstatus price frames into a standard layout."""
+
+    frame = frame.copy()
+
+    ts_col = _detect_column(frame, _TIME_COLUMN_CANDIDATES)
+    loc_col = _detect_column(frame, _LOCATION_COLUMN_CANDIDATES)
+    price_col = _detect_column(frame, _PRICE_COLUMN_CANDIDATES)
+
+    if not ts_col or not loc_col or not price_col:
+        missing = {
+            "timestamp": ts_col,
+            "location": loc_col,
+            "price": price_col,
+        }
+        raise ValueError(f"Unable to normalize price frame – missing columns: {missing}")
+
+    frame["timestamp"] = pd.to_datetime(frame[ts_col], utc=True, errors="coerce")
+    frame["zone"] = frame[loc_col].map(normalize_location)
+    frame["price"] = pd.to_numeric(frame[price_col], errors="coerce")
+
+    frame = frame.dropna(subset=["timestamp", "zone", "price"])
+    frame["timestamp"] = frame["timestamp"].dt.floor("H")
+
+    # Average within the hour in case higher frequency data is returned
+    agg = (
+        frame.groupby(["zone", "timestamp"], as_index=False)["price"].mean()
+    )
+
+    return agg
+
+
+def _prepare_load_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    """Normalize system load frames into a standard layout."""
+
+    frame = frame.copy()
+
+    ts_col = _detect_column(frame, _TIME_COLUMN_CANDIDATES)
+    load_col = _detect_column(frame, _LOAD_COLUMN_CANDIDATES)
+
+    if not ts_col or not load_col:
+        missing = {"timestamp": ts_col, "load": load_col}
+        raise ValueError(f"Unable to normalize load frame – missing columns: {missing}")
+
+    frame["timestamp"] = pd.to_datetime(frame[ts_col], utc=True, errors="coerce")
+    frame["system_load"] = pd.to_numeric(frame[load_col], errors="coerce")
+
+    frame = frame.dropna(subset=["timestamp", "system_load"])
+    frame["timestamp"] = frame["timestamp"].dt.floor("H")
+
+    agg = (
+        frame.groupby("timestamp", as_index=False)["system_load"].mean()
+    )
+
+    return agg
+
+
+def _call_ercot(method_names: Iterable[str], *args, **kwargs) -> pd.DataFrame:
+    """Call one of the potential gridstatus methods that provide data."""
+
+    client = Ercot()
+    last_error: Optional[Exception] = None
+
+    for name in method_names:
+        if not hasattr(client, name):
+            continue
+        method = getattr(client, name)
+        try:
+            logger.debug("Calling gridstatus.Ercot.%s", name)
+            return method(*args, **kwargs)
+        except Exception as exc:  # pragma: no cover - depends on gridstatus runtime
+            logger.warning("gridstatus method %s failed: %s", name, exc)
+            last_error = exc
+    if last_error:
+        raise last_error
+    raise AttributeError(
+        f"gridstatus.Ercot is missing expected methods: {', '.join(method_names)}"
+    )
+
+
+def fetch_rtm_prices(start: datetime, end: datetime) -> pd.DataFrame:
+    """Fetch RTM prices from ERCOT for the requested interval."""
+
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
+
+    method_names = ["get_lmp", "get_prices", "get_real_time_prices"]
+
+    frames: List[pd.DataFrame] = []
+    try:
+        raw = _call_ercot(method_names, start=start, end=end, market="RTM")
+        frames.append(_prepare_price_frame(pd.DataFrame(raw)))
+    except TypeError:
+        # Fallback to per-day requests for gridstatus versions that require a date argument.
+        current = start
+        while current.date() <= end.date():
+            raw = _call_ercot(method_names, date=current.date(), market="RTM")
+            frames.append(_prepare_price_frame(pd.DataFrame(raw)))
+            current += timedelta(days=1)
+
+    if not frames:
+        return pd.DataFrame(columns=["zone", "timestamp", "price"])
+
+    combined = pd.concat(frames, ignore_index=True)
+    combined = combined[combined["zone"].isin(CANONICAL_LOCATIONS)]
+    combined = combined.drop_duplicates(subset=["zone", "timestamp"])
+    return combined.sort_values(["zone", "timestamp"]).reset_index(drop=True)
+
+
+def fetch_system_load(start: datetime, end: datetime) -> pd.DataFrame:
+    """Fetch system load for the requested interval."""
+
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
+
+    method_names = ["get_load", "get_system_load", "get_actual_load"]
+
+    frames: List[pd.DataFrame] = []
+    try:
+        raw = _call_ercot(method_names, start=start, end=end)
+        frames.append(_prepare_load_frame(pd.DataFrame(raw)))
+    except TypeError:
+        current = start
+        while current.date() <= end.date():
+            raw = _call_ercot(method_names, date=current.date())
+            frames.append(_prepare_load_frame(pd.DataFrame(raw)))
+            current += timedelta(days=1)
+
+    if not frames:
+        return pd.DataFrame(columns=["timestamp", "system_load"])
+
+    load_frame = pd.concat(frames, ignore_index=True)
+    load_frame = load_frame.drop_duplicates(subset=["timestamp"])
+    return load_frame.sort_values("timestamp").reset_index(drop=True)
+
+
+def fetch_dataset(config: Optional[FetchConfig] = None) -> pd.DataFrame:
+    """Fetch combined RTM price and system load data for analysis."""
+
+    if config is None:
+        config = FetchConfig()
+
+    start = config.start_time
+    end = config.end_time
+
+    logger.info("Fetching RTM prices between %s and %s", start, end)
+    price_df = fetch_rtm_prices(start, end)
+
+    logger.info("Fetching system load between %s and %s", start, end)
+    load_df = fetch_system_load(start, end)
+
+    if price_df.empty:
+        return pd.DataFrame(columns=["timestamp", "zone", "price", "system_load"])
+
+    dataset = price_df.merge(load_df, on="timestamp", how="left")
+    dataset = dataset.sort_values(["zone", "timestamp"]).reset_index(drop=True)
+    dataset["system_load"] = dataset["system_load"].ffill()
+
+    return dataset

--- a/app/locations.py
+++ b/app/locations.py
@@ -1,0 +1,62 @@
+"""Location utilities for ERCOT zones and hubs."""
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+CANONICAL_LOCATIONS: Dict[str, str] = {
+    "NORTH": "NORTH",
+    "SOUTH": "SOUTH",
+    "HOUSTON": "HOUSTON",
+    "WEST": "WEST",
+    "HB_NORTH": "HB_NORTH",
+    "HB_SOUTH": "HB_SOUTH",
+    "HB_HOUSTON": "HB_HOUSTON",
+    "HB_WEST": "HB_WEST",
+}
+
+LOCATION_ALIASES = {
+    "NORTH ZONE": "NORTH",
+    "SOUTH ZONE": "SOUTH",
+    "HOUSTON ZONE": "HOUSTON",
+    "WEST ZONE": "WEST",
+    "LZ_NORTH": "NORTH",
+    "LZ_SOUTH": "SOUTH",
+    "LZ_HOUSTON": "HOUSTON",
+    "LZ_WEST": "WEST",
+    "HB NORTH": "HB_NORTH",
+    "HB SOUTH": "HB_SOUTH",
+    "HB HOUSTON": "HB_HOUSTON",
+    "HB WEST": "HB_WEST",
+    "HB_NORTH_HUB": "HB_NORTH",
+    "HB_SOUTH_HUB": "HB_SOUTH",
+    "HB_HOUSTON_HUB": "HB_HOUSTON",
+    "HB_WEST_HUB": "HB_WEST",
+    "NORTH HUB": "HB_NORTH",
+    "SOUTH HUB": "HB_SOUTH",
+    "HOUSTON HUB": "HB_HOUSTON",
+    "WEST HUB": "HB_WEST",
+}
+
+
+def normalize_location(raw: str | None) -> Optional[str]:
+    if raw is None:
+        return None
+
+    value = str(raw).strip().upper()
+    value = value.replace("-", "_").replace(" ", "_")
+
+    if value in CANONICAL_LOCATIONS:
+        return value
+
+    if value in LOCATION_ALIASES:
+        return LOCATION_ALIASES[value]
+
+    for prefix in ("LZ_", "HZ_", "HZON_", "LOAD_ZONE_", "HB_"):
+        if value.startswith(prefix):
+            candidate = value[len(prefix) :]
+            if candidate in CANONICAL_LOCATIONS:
+                return candidate
+            if candidate in LOCATION_ALIASES:
+                return LOCATION_ALIASES[candidate]
+
+    return None

--- a/app/sentiment.py
+++ b/app/sentiment.py
@@ -1,0 +1,119 @@
+"""Sentiment scoring utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+
+SENTIMENT_THRESHOLDS = {
+    "green": 70,
+    "yellow": 40,
+}
+
+
+@dataclass
+class SentimentWeights:
+    price: float = 0.6
+    load: float = 0.4
+
+    def normalize(self) -> "SentimentWeights":
+        total = self.price + self.load
+        if total == 0:
+            return SentimentWeights(price=0.6, load=0.4)
+        return SentimentWeights(price=self.price / total, load=self.load / total)
+
+
+def _rolling_median(series: pd.Series, window: int, min_periods: int) -> pd.Series:
+    return series.rolling(window=window, min_periods=min_periods).median()
+
+
+def _rolling_mad(series: pd.Series, window: int, min_periods: int) -> pd.Series:
+    def mad(values: np.ndarray) -> float:
+        median = np.median(values)
+        return float(np.median(np.abs(values - median)))
+
+    return series.rolling(window=window, min_periods=min_periods).apply(mad, raw=True)
+
+
+def _rolling_mean(series: pd.Series, window: int, min_periods: int) -> pd.Series:
+    return series.rolling(window=window, min_periods=min_periods).mean()
+
+
+def _robust_z_score(values: pd.Series, baseline: pd.Series, mad: pd.Series) -> pd.Series:
+    mad_safe = mad.copy()
+    mad_safe[mad_safe == 0] = np.nan
+    z = 0.6745 * (values - baseline) / mad_safe
+    return z.fillna(0.0)
+
+
+def _convert_z_to_score(z: pd.Series) -> pd.Series:
+    clipped = z.clip(lower=-2, upper=2)
+    score = (1 - ((clipped + 2) / 4.0)) * 100
+    return score.clip(lower=0, upper=100)
+
+
+def _convert_pct_to_score(pct: pd.Series) -> pd.Series:
+    clipped = pct.clip(lower=-0.2, upper=0.2)
+    score = (1 - ((clipped + 0.2) / 0.4)) * 100
+    return score.clip(lower=0, upper=100)
+
+
+def _sentiment_bucket(value: float) -> Literal["green", "yellow", "red"]:
+    if value >= SENTIMENT_THRESHOLDS["green"]:
+        return "green"
+    if value >= SENTIMENT_THRESHOLDS["yellow"]:
+        return "yellow"
+    return "red"
+
+
+def compute_sentiment(df: pd.DataFrame, window_hours: int = 24 * 7,
+                      min_periods: int = 24, weights: SentimentWeights | None = None) -> pd.DataFrame:
+    """Compute consumer sentiment scores for each zone/hour."""
+
+    if df.empty:
+        return df.assign(
+            price_baseline=pd.Series(dtype="float64"),
+            price_score=pd.Series(dtype="float64"),
+            load_baseline=pd.Series(dtype="float64"),
+            load_score=pd.Series(dtype="float64"),
+            sentiment=pd.Series(dtype="float64"),
+            sentiment_bucket=pd.Series(dtype="object"),
+        )
+
+    if weights is None:
+        weights = SentimentWeights().normalize()
+    else:
+        weights = weights.normalize()
+
+    df = df.copy()
+    df = df.sort_values(["zone", "timestamp"]).reset_index(drop=True)
+
+    grouped = df.groupby("zone", group_keys=False)
+
+    df["price_baseline"] = grouped["price"].transform(
+        lambda series: _rolling_median(series, window_hours, min_periods)
+    )
+    df["price_mad"] = grouped["price"].transform(
+        lambda series: _rolling_mad(series, window_hours, min_periods)
+    )
+    df["price_z"] = _robust_z_score(df["price"], df["price_baseline"], df["price_mad"])
+    df["price_score"] = _convert_z_to_score(df["price_z"])
+
+    df["load_baseline"] = grouped["system_load"].transform(
+        lambda series: _rolling_mean(series, window_hours, min_periods)
+    )
+    # Avoid division by zero when baseline is missing.
+    df["load_baseline"] = df["load_baseline"].replace(0, np.nan)
+    df["load_pct_dev"] = (df["system_load"] - df["load_baseline"]) / df["load_baseline"]
+    df["load_pct_dev"] = df["load_pct_dev"].replace([np.inf, -np.inf], np.nan).fillna(0.0)
+    df["load_score"] = _convert_pct_to_score(df["load_pct_dev"])
+
+    df["sentiment"] = (
+        df["price_score"] * weights.price + df["load_score"] * weights.load
+    )
+    df["sentiment"] = df["sentiment"].clip(lower=0, upper=100)
+    df["sentiment_bucket"] = df["sentiment"].apply(_sentiment_bucket)
+
+    return df

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,0 +1,60 @@
+"""Storage helpers for the ERCOT dataset."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+DATA_PATH = Path("data/ercot.parquet")
+
+
+def ensure_directory(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def load_dataset(path: Path = DATA_PATH) -> pd.DataFrame:
+    """Load the persisted dataset from disk."""
+
+    if not path.exists():
+        return pd.DataFrame(columns=["timestamp", "zone", "price", "system_load", "sentiment"])
+
+    df = pd.read_parquet(path)
+    if "timestamp" in df.columns:
+        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
+    return df.sort_values(["zone", "timestamp"]).reset_index(drop=True)
+
+
+def append_and_dedupe(existing: pd.DataFrame, new_rows: pd.DataFrame) -> pd.DataFrame:
+    """Combine new records with existing ones while removing duplicates."""
+
+    if existing.empty:
+        combined = new_rows.copy()
+    else:
+        combined = pd.concat([existing, new_rows], ignore_index=True)
+
+    combined = combined.drop_duplicates(subset=["timestamp", "zone"], keep="last")
+    combined = combined.sort_values(["zone", "timestamp"]).reset_index(drop=True)
+    return combined
+
+
+def save_dataset(df: pd.DataFrame, path: Path = DATA_PATH) -> None:
+    ensure_directory(path)
+    df.to_parquet(path, index=False)
+
+
+def upsert_dataset(new_rows: pd.DataFrame, path: Path = DATA_PATH) -> pd.DataFrame:
+    """Load, merge, de-duplicate, and persist the dataset."""
+
+    existing = load_dataset(path)
+    combined = append_and_dedupe(existing, new_rows)
+    save_dataset(combined, path)
+    return combined
+
+
+def get_available_zones(df: pd.DataFrame | None = None) -> Iterable[str]:
+    if df is None:
+        df = load_dataset()
+    if df.empty or "zone" not in df.columns:
+        return []
+    return sorted(df["zone"].unique())

--- a/collector.py
+++ b/collector.py
@@ -1,0 +1,75 @@
+"""Command-line collector for ERCOT RTM data."""
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+from app.fetch import FetchConfig, fetch_dataset
+from app.sentiment import compute_sentiment
+from app.storage import (
+    DATA_PATH,
+    append_and_dedupe,
+    load_dataset,
+    save_dataset,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def collect_and_update(config: FetchConfig, output_path: Path = DATA_PATH) -> pd.DataFrame:
+    """Fetch new data, merge with the existing dataset, and persist it."""
+
+    logger.info("Starting data collection")
+    fresh = fetch_dataset(config)
+    if fresh.empty:
+        logger.warning("No new data was returned by gridstatus")
+        return load_dataset(output_path)
+
+    logger.info("Loaded %d rows from gridstatus", len(fresh))
+
+    existing = load_dataset(output_path)
+    logger.info("Existing dataset contains %d rows", len(existing))
+
+    combined = append_and_dedupe(existing, fresh)
+    logger.info("Combined dataset contains %d rows after dedupe", len(combined))
+
+    enriched = compute_sentiment(combined)
+    save_dataset(enriched, output_path)
+    logger.info("Persisted dataset to %s", output_path)
+
+    return enriched
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Collect ERCOT RTM data")
+    parser.add_argument(
+        "--lookback",
+        type=int,
+        default=FetchConfig.lookback_hours,
+        help="Number of hours in the past to refresh from gridstatus",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DATA_PATH,
+        help="Path to the parquet file",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+    )
+    config = FetchConfig(lookback_hours=args.lookback)
+    collect_and_update(config, args.output)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+gridstatus>=0.20.0
+pandas>=2.0
+numpy>=1.24
+pyarrow>=12.0
+streamlit>=1.26
+plotly>=5.15
+fastapi>=0.103
+uvicorn[standard]>=0.22

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,162 @@
+"""Streamlit dashboard for ERCOT RTM data and sentiment."""
+from __future__ import annotations
+
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+import streamlit as st
+
+from app.sentiment import SENTIMENT_THRESHOLDS
+from app.storage import get_available_zones, load_dataset
+
+TIMEZONES = {
+    "UTC": ZoneInfo("UTC"),
+    "CST/CDT": ZoneInfo("America/Chicago"),
+}
+
+COLOR_MAP = {
+    "green": "#2ecc71",
+    "yellow": "#f1c40f",
+    "red": "#e74c3c",
+}
+
+
+@st.cache_data(ttl=300)
+def load_data() -> pd.DataFrame:
+    return load_dataset()
+
+
+def convert_timezone(df: pd.DataFrame, tz: ZoneInfo) -> pd.DataFrame:
+    if df.empty:
+        return df
+    converted = df.copy()
+    converted["timestamp"] = converted["timestamp"].dt.tz_convert(tz)
+    return converted
+
+
+def format_number(value: float, suffix: str) -> str:
+    return f"{value:,.2f}{suffix}"
+
+
+def build_price_load_chart(df: pd.DataFrame) -> go.Figure:
+    fig = make_subplots(specs=[[{"secondary_y": True}]])
+    fig.add_trace(
+        go.Scatter(
+            x=df["timestamp"],
+            y=df["price"],
+            mode="lines",
+            name="RTM Price ($/MWh)",
+            line=dict(color="#1f77b4"),
+        ),
+        secondary_y=False,
+    )
+    fig.add_trace(
+        go.Bar(
+            x=df["timestamp"],
+            y=df["system_load"],
+            name="System Load (MW)",
+            marker_color="#ff7f0e",
+            opacity=0.6,
+        ),
+        secondary_y=True,
+    )
+    fig.update_layout(
+        margin=dict(l=40, r=40, t=40, b=40),
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+    )
+    fig.update_yaxes(title_text="Price ($/MWh)", secondary_y=False)
+    fig.update_yaxes(title_text="System Load (MW)", secondary_y=True)
+    return fig
+
+
+def build_sentiment_chart(df: pd.DataFrame) -> go.Figure:
+    fig = go.Figure()
+    for bucket, color in COLOR_MAP.items():
+        subset = df[df["sentiment_bucket"] == bucket]
+        if subset.empty:
+            continue
+        fig.add_trace(
+            go.Scatter(
+                x=subset["timestamp"],
+                y=subset["sentiment"],
+                mode="lines+markers",
+                name=bucket.capitalize(),
+                marker=dict(color=color, size=8),
+                line=dict(color=color, width=2),
+            )
+        )
+    fig.add_hrect(
+        y0=SENTIMENT_THRESHOLDS["green"],
+        y1=100,
+        fillcolor=COLOR_MAP["green"],
+        opacity=0.1,
+        line_width=0,
+    )
+    fig.add_hrect(
+        y0=SENTIMENT_THRESHOLDS["yellow"],
+        y1=SENTIMENT_THRESHOLDS["green"],
+        fillcolor=COLOR_MAP["yellow"],
+        opacity=0.1,
+        line_width=0,
+    )
+    fig.add_hrect(
+        y0=0,
+        y1=SENTIMENT_THRESHOLDS["yellow"],
+        fillcolor=COLOR_MAP["red"],
+        opacity=0.1,
+        line_width=0,
+    )
+    fig.update_layout(
+        margin=dict(l=40, r=40, t=40, b=40),
+        yaxis=dict(range=[0, 100], title="Sentiment"),
+    )
+    return fig
+
+
+def main() -> None:
+    st.set_page_config(page_title="ERCOT RTM Dashboard", layout="wide")
+    st.title("ERCOT Real-Time Market Dashboard")
+
+    data = load_data()
+
+    if data.empty:
+        st.info("No data is available yet. Run `collector.py` to populate the dataset.")
+        return
+
+    zones = get_available_zones(data)
+    default_zone = zones[0] if zones else None
+    selected_zone = st.selectbox("Select Zone or Hub", options=zones, index=0 if default_zone else None)
+
+    tz_label = st.radio("Timezone", options=list(TIMEZONES.keys()), horizontal=True)
+    tz = TIMEZONES[tz_label]
+
+    zone_data = data[data["zone"] == selected_zone]
+    zone_data = zone_data.sort_values("timestamp")
+    zone_data = convert_timezone(zone_data, tz)
+
+    latest = zone_data.iloc[-1]
+    st.markdown("### Key Metrics")
+    col1, col2, col3 = st.columns(3)
+    col1.metric("Latest Price", format_number(latest["price"], " $/MWh"))
+    col2.metric("System Load", format_number(latest["system_load"], " MW"))
+    col3.metric("Sentiment", f"{latest['sentiment']:.1f}",
+                delta=f"Bucket: {latest['sentiment_bucket'].capitalize()}")
+
+    tab1, tab2 = st.tabs(["Price & Load", "Sentiment"])
+
+    with tab1:
+        st.plotly_chart(build_price_load_chart(zone_data), use_container_width=True)
+
+    with tab2:
+        st.plotly_chart(build_sentiment_chart(zone_data), use_container_width=True)
+
+    st.caption(
+        "Sentiment weighting: 60% price deviation, 40% load stress."
+        " Values above 70 are favorable, 40–69 cautionary, below 40 poor."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- build ERCOT RTM collector that normalizes hub/zone names, stores hourly parquet data, and computes sentiment scores
- add Streamlit dashboard with KPI cards, dual-axis price/load view, and sentiment visualization
- expose optional FastAPI endpoints, Dockerfile, hourly GitHub Action, and documentation for running, automation, and deployment

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c8743a732883299313e543515fc238